### PR TITLE
docs(readme): incluir badge do ServeRest

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Automação da API do Site: https://serverest.dev/
+[![Badge ServeRest](https://img.shields.io/badge/API-ServeRest-green)](https://github.com/PauloGoncalvesBH/ServeRest/)
 
 O projeto foi desenvolvido utilizando Cypress e o padrão Page Objects. Com o uso da biblioteca faker para criação de dados.
 


### PR DESCRIPTION
No README vai ser exibido o badge do ServeRest com link para o repositório.

@guilhermelemke muito bom o seu projeto de estudos de API e vai ajudar várias pessoas 🥳 
Se precisar de ajuda pode me chamar no linkedin. Tanto sobre o ServeRest quanto sobre rodar o projeto no Github Actions.